### PR TITLE
Fix `argv` parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.config*

--- a/elf_ctx.c
+++ b/elf_ctx.c
@@ -163,7 +163,7 @@ void elf_ctx_init(struct ukarch_ctx *ctx, struct elf_prog *prog,
 	 */
 	elfvec_len = ((ARRAY_SIZE(auxv) + 1) * sizeof(struct auxv_entry))
 		+ (envc + 1) * sizeof(uintptr_t)
-		+ ((argc - 1) + 1) * sizeof(uintptr_t)
+		+ (argc + 1) * sizeof(uintptr_t)
 		+ sizeof(long);
 
 	ctx->sp = ALIGN_DOWN(ctx->sp - elfvec_len, UKARCH_SP_ALIGN)
@@ -195,9 +195,9 @@ void elf_ctx_init(struct ukarch_ctx *ctx, struct elf_prog *prog,
 	/* Same as envp, pushing NULL first */
 	ukarch_rctx_stackpush(ctx, (long) NULL);
 	if (argc)
-		for(i=argc-1; i>0; --i)
+		for (i = argc - 1; i >= 0; --i)
 			ukarch_rctx_stackpush(ctx, (uintptr_t) argv[i]);
-	ukarch_rctx_stackpush(ctx, (long) argc - 1);
+	ukarch_rctx_stackpush(ctx, (long) argc);
 
 	/* ctx will enter the entry point with cleared registers. */
 	ukarch_ctx_init(ctx, ctx->sp, 0x0, prog->entry);


### PR DESCRIPTION
Argument parsing code always skipped `argv[0]` when passing the argument vector to the ELF program, which is not the expected behaviour when `CONFIG_APPELFLOADER_CUSTOMAPPNAME=n`.

After these changes, the loader does as follows:

- `CONFIG_APPELFLOADER_CUSTOMAPPNAME=n`: argv[0] (kernel image name) is set as program name;
- `CONFIG_APPELFLOADER_CUSTOMAPPNAME=y`: argv[1] is set as program name.

This PR is built upon #9 since both branches touch on the argument parsing/counting code.

