### PR TITLE
Add missing uk/config.h

### DIFF
--- a/elf_load.c
+++ b/elf_load.c
@@ -41,6 +41,8 @@
  * (see file /LICENSE in the HermiTux Kernel repository).
  */
 
+#include <uk/config.h>
+
 #include <libelf.h>
 #include <gelf.h>
 #include <errno.h>


### PR DESCRIPTION
The elfloader conditionally includes system headers without also including the config header. Therefore, the system headers are never included.