### PR TITLE
`mmap` each ELF segment if `CONFIG_LIBPOSIXMMAP` is enabled

### DIFF
--- a/elf_load.c
+++ b/elf_load.c
@@ -396,14 +396,10 @@ static int elf_load_fdread(struct elf_prog *elf_prog, Elf *elf, int fd)
 					  elf_prog->name, strerror(-ret));
 				goto err_out;
 			}
-			ret = elf_load_do_fdread(fd, phdr.p_offset,
-						 elf_prog->interp.path,
-						 phdr.p_filesz);
-			if (ret < 0) {
-				uk_pr_err("%s: Read error: %s\n",
-					  elf_prog->name, strerror(-ret));
-				goto err_free_interp;
-			}
+
+			memcpy(elf_prog->interp.path,
+			       &elf->e_rawfile[phdr.p_offset], phdr.p_filesz);
+
 			/* Enforce zero termination, this should normally
 			 * be the case with the PT_INTERP section content.
 			 * We are playing safe here.

--- a/elf_prog.h
+++ b/elf_prog.h
@@ -63,6 +63,8 @@ struct elf_prog {
 		char *path;
 		struct elf_prog *prog;
 	} interp;
+	uintptr_t lowerl;
+	uintptr_t upperl;
 	size_t align;
 };
 

--- a/elf_prog.h
+++ b/elf_prog.h
@@ -63,6 +63,7 @@ struct elf_prog {
 		char *path;
 		struct elf_prog *prog;
 	} interp;
+	size_t align;
 };
 
 /**


### PR DESCRIPTION
Deprecate use of `elf_load_do_fdread` and `uk_memalign` in favor of
`mmap`ing each ELF segment individually. This allows for massive
performance improvements in conjunction with on-demand paging.
    
The first address of the executable will be the first result of the
first time call to `mmap` on the first `PT_LOAD` and everything else
will be contiguously mapped by using the `MAP_FIXED` flag.

Depends on [`lib-libelf #3`](https://github.com/unikraft/lib-libelf/pull/3).