### PR TITLE
Add sqlite3 to run.yaml

### DIFF
--- a/scripts/run.yaml
+++ b/scripts/run.yaml
@@ -9,3 +9,8 @@ runs:
     command: /helloworld
     memory: 64
     networking: False
+  - name: sqlite3
+    rootfs: ../dynamic-apps/sqlite3
+    command: /usr/bin/sqlite3 
+    memory: 64
+    networking: False


### PR DESCRIPTION
Update run.yaml to include sqlite3
sqlite3 shell appeared correctly after the script patch "-enable-kvm -cpu host"