### PR TITLE
Added iputils to run.yaml, running ping, tracepath, arping, and clockdiff

### DIFF
--- a/scripts/run.yaml
+++ b/scripts/run.yaml
@@ -19,3 +19,23 @@ runs:
     command: ./usr/bin/perl hello.pl
     memory: 64
     networking: False
+  - name: iputils
+    rootfs: ../dynamic-apps/iputils
+    command: /bin/ping 8.8.8.8
+    memory: 64
+    networking: True
+  - name: iputils
+    rootfs: ../dynamic-apps/iputils
+    command: /bin/tracepath 8.8.8.8
+    memory: 64
+    networking: True
+  - name: iputils
+    rootfs: ../dynamic-apps/iputils
+    command: /bin/arping 8.8.8.8
+    memory: 64
+    networking: True
+  - name: iputils
+    rootfs: ../dynamic-apps/iputils
+    command: /bin/clockdiff 8.8.8.8
+    memory: 64
+    networking: True

--- a/scripts/run.yaml
+++ b/scripts/run.yaml
@@ -14,3 +14,8 @@ runs:
     command: /usr/bin/sqlite3 
     memory: 64
     networking: False
+  - name: perl
+    rootfs: ../dynamic-apps/lang/perl
+    command: ./usr/bin/perl hello.pl
+    memory: 64
+    networking: False


### PR DESCRIPTION
It is known that this does not run as intended - running `./scripts/run/qemu-x86_64-9pfs-iputils.sh` results in this error: `[    0.260716] CRIT: [liblwip] <api_msg.c @  744> netconn_alloc: undefined netconn_typeAssertion failure: !(1)`

UBC Hackathon 2023
Group Name: Quadruple Trouble