### PR TITLE
Make VDSO creation work for cross-compilation and Darwin

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1,9 +1,0 @@
-$(APPELFLOADER_BASE)/vdso/libvdso.o:
-	gcc $(APPELFLOADER_BASE)/vdso/vdso.c -c -o $(APPELFLOADER_BASE)/vdso/libvdso.o -fPIC -O2 -nostdlib
-	@APPELFLOADER_BASE=$(APPELFLOADER_BASE) VDSO_MAGIC_NUMBER=0x369C217100000000 $(APPELFLOADER_BASE)/vdso/add_symbol.sh
-
-$(APPELFLOADER_BASE)/vdso/libvdso.so: $(APPELFLOADER_BASE)/vdso/libvdso.o
-	ld $(APPELFLOADER_BASE)/vdso/libvdso.o -o $(APPELFLOADER_BASE)/vdso/libvdso.so --hash-style=both -soname unikraft-vdso.so.1 -shared -T $(APPELFLOADER_BASE)/vdso/vdso.lds
-
-$(APPELFLOADER_BASE)/vdso/vdso-image.c: $(APPELFLOADER_BASE)/vdso/libvdso.so
-	python3 $(APPELFLOADER_BASE)/vdso/bin2c.py $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $(APPELFLOADER_BASE)/vdso/libvdso.so $(APPELFLOADER_BASE)/vdso/vdso-image.c

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -12,7 +12,15 @@ UK_PROVIDED_SYSCALLS-$(CONFIG_APPELFLOADER_BRK) += brk-1
 APPELFLOADER_SRCS-$(CONFIG_APPELFLOADER_ARCH_PRCTL) += $(APPELFLOADER_BASE)/arch_prctl.c
 UK_PROVIDED_SYSCALLS-$(CONFIG_APPELFLOADER_ARCH_PRCTL) += arch_prctl-3
 
-include $(APPELFLOADER_BASE)/Makefile.rules
-
 APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BASE)/vdso/vdso-image.c
 APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BASE)/vdso/vsyscall.c
+
+$(APPELFLOADER_BASE)/vdso/libvdso.o:
+	gcc $(APPELFLOADER_BASE)/vdso/vdso.c -c -o $(APPELFLOADER_BASE)/vdso/libvdso.o -fPIC -O2 -nostdlib
+	@APPELFLOADER_BASE=$(APPELFLOADER_BASE) VDSO_MAGIC_NUMBER=0x369C217100000000 $(APPELFLOADER_BASE)/vdso/add_symbol.sh
+
+$(APPELFLOADER_BASE)/vdso/libvdso.so: $(APPELFLOADER_BASE)/vdso/libvdso.o
+	ld $(APPELFLOADER_BASE)/vdso/libvdso.o -o $(APPELFLOADER_BASE)/vdso/libvdso.so --hash-style=both -soname unikraft-vdso.so.1 -shared -T $(APPELFLOADER_BASE)/vdso/vdso.lds
+
+$(APPELFLOADER_BASE)/vdso/vdso-image.c: $(APPELFLOADER_BASE)/vdso/libvdso.so
+	python3 $(APPELFLOADER_BASE)/vdso/bin2c.py $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $(APPELFLOADER_BASE)/vdso/libvdso.so $(APPELFLOADER_BASE)/vdso/vdso-image.c

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -16,16 +16,20 @@ APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BUILD)/vdso-image.c
 APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BASE)/vdso/vsyscall.c
 
 $(APPELFLOADER_BUILD)/vdso.o: $(APPELFLOADER_BASE)/vdso/vdso.c
-	$(CC) $< -c -o $@ -fPIC -O2 -nostdlib
+	$(call build_cmd,CC,appelfloader,$(notdir $@), \
+		$(CC) $< -c -o $@ -fPIC -O2 -nostdlib)
 
 $(APPELFLOADER_BUILD)/vdso.patched.o: $(APPELFLOADER_BUILD)/vdso.o $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf
-	OBJCOPY_CMD=$(OBJCOPY) APPELFLOADER_BASE=$(APPELFLOADER_BASE) VDSO_MAGIC_NUMBER=0x369C217100000000 $(APPELFLOADER_BASE)/vdso/add_symbol.sh $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $< $@
+	$(call build_cmd,ADDSYM,appelfloader,$(notdir $@), \
+		OBJCOPY_CMD=$(OBJCOPY) APPELFLOADER_BASE=$(APPELFLOADER_BASE) VDSO_MAGIC_NUMBER=0x369C217100000000 $(APPELFLOADER_BASE)/vdso/add_symbol.sh $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $< $@)
 
 $(APPELFLOADER_BUILD)/libvdso.so: $(APPELFLOADER_BUILD)/vdso.patched.o $(APPELFLOADER_BASE)/vdso/vdso.lds
-	$(LD) $< -o $@ -nostdlib -Wl,--hash-style=both -Wl,-soname=unikraft-vdso.so.1 -Wl,-shared -Wl,-T,$(APPELFLOADER_BASE)/vdso/vdso.lds
+	$(call build_cmd,LD,appelfloader,$(notdir $@), \
+		$(LD) $< -o $@ -nostdlib -Wl$(comma)--hash-style=both -Wl$(comma)-soname=unikraft-vdso.so.1 -Wl$(comma)-shared -Wl$(comma)-T$(comma)$(APPELFLOADER_BASE)/vdso/vdso.lds)
 
 $(APPELFLOADER_BUILD)/vdso-image.c: $(APPELFLOADER_BUILD)/libvdso.so $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf
-	$(PYTHON) $(APPELFLOADER_BASE)/vdso/bin2c.py $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $< $@
+	$(call build_cmd,PYTHON,appelfloader,$(notdir $@), \
+		$(PYTHON) $(APPELFLOADER_BASE)/vdso/bin2c.py $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $< $@)
 
 APPELFLOADER_CLEAN += $(APPELFLOADER_BUILD)/vdso.o
 APPELFLOADER_CLEAN += $(APPELFLOADER_BUILD)/vdso.patched.o

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -12,15 +12,22 @@ UK_PROVIDED_SYSCALLS-$(CONFIG_APPELFLOADER_BRK) += brk-1
 APPELFLOADER_SRCS-$(CONFIG_APPELFLOADER_ARCH_PRCTL) += $(APPELFLOADER_BASE)/arch_prctl.c
 UK_PROVIDED_SYSCALLS-$(CONFIG_APPELFLOADER_ARCH_PRCTL) += arch_prctl-3
 
-APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BASE)/vdso/vdso-image.c
+APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BUILD)/vdso-image.c
 APPELFLOADER_SRCS-$(CONFIG_VDSO) += $(APPELFLOADER_BASE)/vdso/vsyscall.c
 
-$(APPELFLOADER_BASE)/vdso/libvdso.o:
-	gcc $(APPELFLOADER_BASE)/vdso/vdso.c -c -o $(APPELFLOADER_BASE)/vdso/libvdso.o -fPIC -O2 -nostdlib
-	@APPELFLOADER_BASE=$(APPELFLOADER_BASE) VDSO_MAGIC_NUMBER=0x369C217100000000 $(APPELFLOADER_BASE)/vdso/add_symbol.sh
+$(APPELFLOADER_BUILD)/vdso.o: $(APPELFLOADER_BASE)/vdso/vdso.c
+	$(CC) $< -c -o $@ -fPIC -O2 -nostdlib
 
-$(APPELFLOADER_BASE)/vdso/libvdso.so: $(APPELFLOADER_BASE)/vdso/libvdso.o
-	ld $(APPELFLOADER_BASE)/vdso/libvdso.o -o $(APPELFLOADER_BASE)/vdso/libvdso.so --hash-style=both -soname unikraft-vdso.so.1 -shared -T $(APPELFLOADER_BASE)/vdso/vdso.lds
+$(APPELFLOADER_BUILD)/vdso.patched.o: $(APPELFLOADER_BUILD)/vdso.o $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf
+	OBJCOPY_CMD=$(OBJCOPY) APPELFLOADER_BASE=$(APPELFLOADER_BASE) VDSO_MAGIC_NUMBER=0x369C217100000000 $(APPELFLOADER_BASE)/vdso/add_symbol.sh $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $< $@
 
-$(APPELFLOADER_BASE)/vdso/vdso-image.c: $(APPELFLOADER_BASE)/vdso/libvdso.so
-	python3 $(APPELFLOADER_BASE)/vdso/bin2c.py $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $(APPELFLOADER_BASE)/vdso/libvdso.so $(APPELFLOADER_BASE)/vdso/vdso-image.c
+$(APPELFLOADER_BUILD)/libvdso.so: $(APPELFLOADER_BUILD)/vdso.patched.o $(APPELFLOADER_BASE)/vdso/vdso.lds
+	$(LD) $< -o $@ -nostdlib -Wl,--hash-style=both -Wl,-soname=unikraft-vdso.so.1 -Wl,-shared -Wl,-T,$(APPELFLOADER_BASE)/vdso/vdso.lds
+
+$(APPELFLOADER_BUILD)/vdso-image.c: $(APPELFLOADER_BUILD)/libvdso.so $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf
+	$(PYTHON) $(APPELFLOADER_BASE)/vdso/bin2c.py $(APPELFLOADER_BASE)/vdso/vdso_mapping.conf $< $@
+
+APPELFLOADER_CLEAN += $(APPELFLOADER_BUILD)/vdso.o
+APPELFLOADER_CLEAN += $(APPELFLOADER_BUILD)/vdso.patched.o
+APPELFLOADER_CLEAN += $(APPELFLOADER_BUILD)/libvdso.so
+APPELFLOADER_CLEAN += $(APPELFLOADER_BUILD)/vdso-image.c

--- a/vdso/add_symbol.sh
+++ b/vdso/add_symbol.sh
@@ -1,4 +1,11 @@
+#!/bin/bash
+OBJCOPY_CMD=${OBJCOPY_CMD:-objcopy}
+CONF_FILE=${1}
+IN_FILE=${2}
+OUT_FILE=${3}
+
+cp -f "${IN_FILE}" "${OUT_FILE}"
 while IFS=' ' read -r vdso_symbol _; do
-  objcopy --add-symbol $vdso_symbol=.text:$VDSO_MAGIC_NUMBER,global,function $APPELFLOADER_BASE/vdso/libvdso.o
-  ((VDSO_MAGIC_NUMBER++))
-done < $APPELFLOADER_BASE/vdso/vdso_mapping.conf
+	"${OBJCOPY_CMD}" --add-symbol "${vdso_symbol}=.text:${VDSO_MAGIC_NUMBER},global,function" "${OUT_FILE}"
+	((VDSO_MAGIC_NUMBER++))
+done < "${CONF_FILE}"


### PR DESCRIPTION
This commit reworks the compilation rules for the VDSO so that they can be easily cross-compiled and be compiled on a Darwin environment (MacOS).
The following improvements are implemented:
- The build-system provided compiler and tool commands are called instead of calling the tools (e.g., `gcc`) directly which would create an incompatible VDSO when cross-compiling.
- Any build artifact is created under the appelfloader build path (and not within the sources path).
- Recompilation dependencies are correctly stated.
- The step that adds symbol placeholders is separated from compiling the VDSO template.
- Compiling and linking of the VDSO is done with `-nostartfiles` which avoids the unnnecessary inclusion of start files, like `crt0.o`. Those startfiles are not needed for the VDSO because it provides only some symbols and code that is looked up and used by a libc (and dynamic linker) for performing faster system calls.