### PR TITLE
Do not change real `fs_base` register in `arch_prctl`

### DIFF
--- a/arch_prctl.c
+++ b/arch_prctl.c
@@ -122,7 +122,7 @@ UK_LLSYSCALL_R_DEFINE(long, arch_prctl, long, code, long, addr, long, arg2)
 		case ARCH_SET_FS:
 			uk_pr_debug("arch_prctl option SET_FS(%p)\n",
 				    (void *) addr);
-			writefs((__uptr) addr);
+			_uk_syscall_ultlsp = (__uptr)addr;
 			return 0;
 
 		case ARCH_GET_GS: {
@@ -139,7 +139,7 @@ UK_LLSYSCALL_R_DEFINE(long, arch_prctl, long, code, long, addr, long, arg2)
 				    (void *) addr);
 			if (!addr)
 				return -EINVAL;
-			*((long *) addr) = readfs();
+			*((long *) addr) = _uk_syscall_ultlsp;
 			return 0;
 		}
 


### PR DESCRIPTION
When an application calls `arch_prctl` with `ARCH_SET_FS` we end up modifying the kernel context `fs_base` register. Unikraft core commit 6214d15d9b47 (lib/syscall_shim: TLS pointer of caller") does allow in-kernel callers to differentiate between user app and Unikraft TLS, however, on syscall return,
`__UK_SYSCALL_RETADDR_CLEAR` macro makes a TLS access while we are still in Unikraft context, which results in a TLS access in the area set by the app that previously called `arch_prctl` with `ARCH_SET_FS`.

Fix this by avoiding actual modification of the `fs_base` register and, instead, simply modify the `_uk_syscall_ultlsp` that was introduced with the previously mentioned commit, so that we keep our own `fs_base` while in Unikraft context and also correctly make the app use the newly set `fs_base` when we return from Unikraft context by using the updated `_uk_syscall_ultlsp`.