### PR TITLE
Correctly set `Program Header` offset used for aux vector's `AT_PHDR`

### DIFF
--- a/elf_ctx.c
+++ b/elf_ctx.c
@@ -164,7 +164,7 @@ void elf_ctx_init(struct ukarch_ctx *ctx, struct elf_prog *prog,
 		{ AT_RANDOM, (uintptr_t) rand },
 		{ AT_PHENT, prog->phdr.entsize },
 		{ AT_PHNUM, prog->phdr.num },
-		{ AT_PHDR, prog->start + prog->phdr.off },
+		{ AT_PHDR, (__uptr)prog->vabase + prog->phdr.off },
 #if CONFIG_VDSO
 		{ AT_SYSINFO_EHDR, (long)vdso_image_addr},
 #endif

--- a/elf_load.c
+++ b/elf_load.c
@@ -202,14 +202,6 @@ static int elf_load_parse(struct elf_prog *elf_prog, Elf *elf)
 	uk_pr_debug("%s: base: pie + 0x%"PRIx64", len: 0x%"PRIx64"\n",
 		    elf_prog->name, elf_prog->lowerl, elf_prog->upperl - elf_prog->lowerl);
 
-	/* We do not support yet an img base other than 0 */
-	if (unlikely(elf_prog->lowerl != 0)) {
-		elferr_err("%s: Image base is not 0x0, unsupported\n",
-			   elf_prog->name);
-		ret = -ENOEXEC;
-		goto err_out;
-	}
-
 	elf_prog->phdr.off = ehdr.e_phoff;
 	elf_prog->phdr.num = ehdr.e_phnum;
 	elf_prog->phdr.entsize = ehdr.e_phentsize;

--- a/elf_load.c
+++ b/elf_load.c
@@ -183,19 +183,19 @@ static int elf_load_parse(struct elf_prog *elf_prog, Elf *elf)
 			    (uint64_t) phdr.p_memsz,
 			    (uint64_t) phdr.p_align);
 		uk_pr_debug("%s: \\_ segment at pie + 0x%"PRIx64" (len: 0x%"PRIx64") from file @ 0x%"PRIx64" (len: 0x%"PRIx64")\n",
-			    elf_prog->name, phdr.p_paddr, phdr.p_memsz,
+			    elf_prog->name, phdr.p_vaddr, phdr.p_memsz,
 			    (uint64_t) phdr.p_offset, (uint64_t) phdr.p_filesz);
 
 		if (elf_prog->lowerl == 0 && elf_prog->upperl == 0) {
 			/* first run */
-			elf_prog->lowerl = phdr.p_paddr;
+			elf_prog->lowerl = phdr.p_vaddr;
 			elf_prog->upperl = elf_prog->lowerl + phdr.p_memsz;
 		} else {
 			/* Move lower and upper border */
-			if (phdr.p_paddr < elf_prog->lowerl)
-				elf_prog->lowerl = phdr.p_paddr;
-			if (phdr.p_paddr + phdr.p_memsz > elf_prog->upperl)
-				elf_prog->upperl = phdr.p_paddr + phdr.p_memsz;
+			if (phdr.p_vaddr < elf_prog->lowerl)
+				elf_prog->lowerl = phdr.p_vaddr;
+			if (phdr.p_vaddr + phdr.p_memsz > elf_prog->upperl)
+				elf_prog->upperl = phdr.p_vaddr + phdr.p_memsz;
 		}
 		UK_ASSERT(elf_prog->lowerl <= elf_prog->upperl);
 
@@ -203,7 +203,7 @@ static int elf_load_parse(struct elf_prog *elf_prog, Elf *elf)
 		if (phdr.p_offset <= ehdr.e_phoff &&
 		    ehdr.e_phoff < phdr.p_offset + phdr.p_filesz)
 			elf_prog->phdr.off = ehdr.e_phoff - phdr.p_offset +
-					     phdr.p_paddr;
+					     phdr.p_vaddr;
 	}
 	uk_pr_debug("%s: base: pie + 0x%"PRIx64", len: 0x%"PRIx64"\n",
 		    elf_prog->name, elf_prog->lowerl, elf_prog->upperl - elf_prog->lowerl);
@@ -299,7 +299,7 @@ static int elf_load_imgcpy(struct elf_prog *elf_prog, Elf *elf,
 		if (phdr.p_type != PT_LOAD)
 			continue;
 
-		vastart = phdr.p_paddr + (uintptr_t) elf_prog->vabase;
+		vastart = phdr.p_vaddr + (uintptr_t)elf_prog->vabase;
 		vaend   = vastart + phdr.p_filesz;
 		if (!elf_prog->start || (vastart < elf_prog->start))
 			elf_prog->start = vastart;
@@ -433,7 +433,7 @@ static int do_elf_load_fdphdr_0(struct elf_prog *elf_prog,
 		    (uint64_t)elf_prog->vabase + elf_prog->valen);
 
 
-	vastart = (uintptr_t)mmap((void *)vastart + phdr->p_paddr,
+	vastart = (uintptr_t)mmap((void *)vastart + phdr->p_vaddr,
 				  phdr->p_filesz,
 				  PROT_EXEC | PROT_READ | PROT_WRITE,
 				  MAP_PRIVATE | MAP_FIXED,
@@ -487,9 +487,9 @@ static int do_elf_load_fdphdr_not0(struct elf_prog *elf_prog,
 	 * Therefore, taking care of the address misalignment will also take
 	 * care of the file misalignment.
 	 */
-	delta_p_offset = phdr->p_paddr - PAGE_ALIGN_DOWN(phdr->p_paddr);
+	delta_p_offset = phdr->p_vaddr - PAGE_ALIGN_DOWN(phdr->p_vaddr);
 
-	addr = (void *)PAGE_ALIGN_DOWN((phdr->p_paddr +
+	addr = (void *)PAGE_ALIGN_DOWN((phdr->p_vaddr +
 				       (uintptr_t)elf_prog->vabase));
 
 	uk_pr_debug("%s: Memory mapping 0x%"PRIx64" - 0x%"PRIx64" to 0x%"PRIx64" - 0x%"PRIx64"\n",
@@ -570,7 +570,7 @@ static int elf_load_fdphdr(struct elf_prog *elf_prog, GElf_Phdr *phdr, int fd)
 	uintptr_t vastart, vaend;
 	int ret;
 
-	vastart = phdr->p_paddr + (uintptr_t)elf_prog->vabase;
+	vastart = phdr->p_vaddr + (uintptr_t)elf_prog->vabase;
 	vaend   = vastart + phdr->p_filesz;
 	if (!elf_prog->start || (vastart < elf_prog->start))
 		elf_prog->start = vastart;
@@ -756,7 +756,7 @@ static int elf_load_ptprotect(struct elf_prog *elf_prog, Elf *elf)
 		if (phdr.p_type != PT_LOAD)
 			continue;
 
-		vastart = phdr.p_paddr + (uintptr_t) elf_prog->vabase;
+		vastart = phdr.p_vaddr + (uintptr_t)elf_prog->vabase;
 		vaend   = vastart + phdr.p_memsz;
 		vastart = PAGE_ALIGN_DOWN(vastart);
 		vaend   = PAGE_ALIGN_UP(vaend);


### PR DESCRIPTION
The Program Header offset specified in the ELF Header represents the
in-file offset. If this happens to also be part of a PT_LOAD segment,
this could mean trouble: in-file offsets != in-memory offset.
Although they are almost always the same, it is not uncommon to meet
ELF's whose segment in-file offsets differ from those in memory at
runtime. Thus, this means that we can't actually use the in-file
offset of the Program Headers.
    
Fix this by figuring out the PT_LOAD ELF segment the Program Headers
are part of during `elf_load_parse`: if the in-file offset of the
Program Headers is contained within the in-file contents of that
segment, then we found it. Consequently, obtain the in-memory offset
of the Program Headers by finding the in-file offset of the Program
Headers relative to the start of the segment they are part of
(ehdr->e_phoff - phdr->p_offset) and adding to that the runtime
base address of the ELF segment ( + phdr->p_paddr).
    
Finally, compute `AT_PHDR` based on this new offset and the virtual
address base (elf_prog->vabase), not the start of the actual ELF in
its mapped area (elf_prog->vastart) as they could differ.

Depends on [#63](https://github.com/unikraft/app-elfloader/pull/63)