### PR TITLE
Use default allocators of the current scheduler for stacks/TLS

### DIFF
--- a/main.c
+++ b/main.c
@@ -113,8 +113,11 @@ int main(int argc, char *argv[])
 	const char *progname;
 	struct elf_prog *prog;
 	struct uk_thread *app_thread;
+	struct uk_sched *s = uk_sched_current();
 	uint64_t rand[2];
 	int ret = 0;
+
+	UK_ASSERT(s);
 
 	/*
 	 * Prepare `progname` (and `path`) from command line
@@ -181,11 +184,11 @@ int main(int argc, char *argv[])
 	 * It will have a new stack and an ukarch_ctx
 	 */
 	app_thread = uk_thread_create_container(uk_alloc_get_default(),
-						uk_alloc_get_default(),
+						s->a_stack,
 				 PAGES2BYTES(CONFIG_APPELFLOADER_STACK_NBPAGES),
-						uk_alloc_get_default(),
+						s->a_auxstack,
 						0,
-						uk_alloc_get_default(),
+						s->a_uktls,
 						false,
 						progname,
 						NULL, NULL);
@@ -251,7 +254,7 @@ int main(int argc, char *argv[])
 	/*
 	 * Execute application
 	 */
-	uk_sched_thread_add(uk_sched_current(), app_thread);
+	uk_sched_thread_add(s, app_thread);
 
 	/*
 	 * FIXME: Instead of an infinite wait, wait for application


### PR DESCRIPTION
The scheduler structure now also contains fields allowing customization of the allocators used for stacks as well as auxiliary stacks. Use those instead.

NOTE: Depends on [#1322](https://github.com/unikraft/unikraft/pull/1322)