### PR TITLE
Remove `uk_syscall_` symbols from `exportsyms.uk`

### DIFF
--- a/exportsyms.uk
+++ b/exportsyms.uk
@@ -1,10 +1,4 @@
 main
-uk_syscall_e_brk
-uk_syscall_r_brk
 brk
 sbrk
-uk_syscall_e_arch_prctl
-uk_syscall_r_arch_prctl
-uk_syscall_r_e_arch_prctl
-uk_syscall_e_e_arch_prctl
 arch_prctl


### PR DESCRIPTION
Now that the syscall shim exported `uk_syscall_` symbols are auto-generated, remove the manually added symbols for `brk` and `arch_prctls`.

Depends-on: [#1577](https://github.com/unikraft/unikraft/pull/1577)