### PR TITLE
Silence unused argument warnings for /etc/hostname

### DIFF
--- a/autogen/etc.c
+++ b/autogen/etc.c
@@ -210,7 +210,8 @@ out:
 	return rc;
 }
 
-static int gen_etc_hostname(const char *fpath, mode_t fmode)
+static int gen_etc_hostname(const char *fpath __maybe_unused,
+			    mode_t fmode __maybe_unused)
 {
 	int rc = 0;
 #if CONFIG_APPELFLOADER_AUTOGEN_ETCHOSTNAME


### PR DESCRIPTION
This change silences compile warnings about unused arguments when /etc/hostname is not autogenerated.