### PR TITLE
Config.uk: Support either filesystem stack

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -28,7 +28,7 @@ config APPELFLOADER_DEPENDENCIES
 config APPELFLOADER_ELF_BINFMT
 	bool
 	default y
-	depends on LIBVFSCORE && LIBUKBINFMT
+	depends on HAVE_VFS && LIBUKBINFMT
 	depends on LIBPOSIX_PROCESS_MULTITHREADING
 
 ### App configuration
@@ -38,7 +38,7 @@ choice
 
 	config APPELFLOADER_VFSEXEC
 		bool "VFS"
-		select LIBVFSCORE
+		depends on HAVE_VFS
 		help
 			Loads an ELF executable from the virtual filesystem.
 			elfloader will automatically side-load a dynamic loader

--- a/elf_load.c
+++ b/elf_load.c
@@ -48,11 +48,11 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#if CONFIG_LIBVFSCORE
+#if CONFIG_HAVE_VFS
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#endif /* CONFIG_LIBVFSCORE */
+#endif /* CONFIG_HAVE_VFS */
 #include <uk/assert.h>
 #include <uk/print.h>
 #include <uk/essentials.h>
@@ -346,7 +346,7 @@ err_out:
 	return ret;
 }
 
-#if CONFIG_LIBVFSCORE
+#if CONFIG_HAVE_VFS
 #if CONFIG_LIBPOSIX_MMAP
 /* If vastart + phdr.p_filesz (vastart) < vastart + phdr.p_memsz (vaend),
  * 0 out that remainder, either through memset or through anonymous mappings
@@ -736,7 +736,7 @@ err_free_img:
 err_out:
 	return ret;
 }
-#endif /* CONFIG_LIBVFSCORE */
+#endif /* CONFIG_HAVE_VFS */
 
 #if CONFIG_LIBUKVMEM
 static int elf_load_ptprotect(struct elf_prog *elf_prog, Elf *elf)
@@ -915,7 +915,7 @@ err_out:
 	return ERR2PTR(ret);
 }
 
-#if CONFIG_LIBVFSCORE
+#if CONFIG_HAVE_VFS
 static struct elf_prog *do_elf_load_vfs(struct uk_alloc *a, const char *path,
 					const char *progname, bool nointerp)
 {
@@ -1055,4 +1055,4 @@ err_unload_prog:
 err_out:
 	return ERR2PTR(err);
 }
-#endif /* CONFIG_LIBVFSCORE */
+#endif /* CONFIG_HAVE_VFS */

--- a/elf_prog.h
+++ b/elf_prog.h
@@ -90,7 +90,7 @@ struct elf_prog {
 struct elf_prog *elf_load_img(struct uk_alloc *a, void *img_base,
 			      size_t img_len, const char *progname);
 
-#if CONFIG_LIBVFSCORE
+#if CONFIG_HAVE_VFS
 /**
  * Load an ELF program from a file descriptor region. After loading,
  * the file descriptor can be closed.
@@ -113,7 +113,7 @@ struct elf_prog *elf_load_img(struct uk_alloc *a, void *img_base,
  */
 struct elf_prog *elf_load_vfs(struct uk_alloc *a, const char *path,
 			      const char *progname);
-#endif /* CONFIG_LIBVFSCORE */
+#endif /* CONFIG_HAVE_VFS */
 
 /**
  * Release a loaded ELF program


### PR DESCRIPTION
This changes app-elfloader's VFS dependencies from hardcoded vfscore to the more general HAVE_VFS that supports either filesystem stack. OOTB configuration still implies vfscore by default for the time being.

Depend on the following PR in libelf:
- https://github.com/unikraft/lib-libelf/pull/6

Requires the following PR to Unikraft core to have any real effect (although it does not depend on it):
- https://github.com/unikraft/unikraft/pull/1610