### PR TITLE
Support either filesystem stack for /etc generation

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -145,7 +145,7 @@ config APPELFLOADER_VDSO
 
 menuconfig APPELFLOADER_AUTOGEN
 	bool "Auto-generate configuration files (HFS)"
-	depends on LIBVFSCORE
+	depends on HAVE_VFS
 	default y
 	help
 		Automatically generate configuration files according to the


### PR DESCRIPTION
Commit fd35d5b947a9 ("Config.uk: Support either filesystem stack") forgot to update the configuration for /etc generation to also be usable with filesystem stacks other than vfscore.

Change it accordingly.