### PR TITLE
Add Hyperlight platform support for deferred ELF execution

### DIFF
--- a/elf_ctx.c
+++ b/elf_ctx.c
@@ -83,6 +83,7 @@
 #define AT_EXECFN		31
 #define AT_SYSINFO_EHDR		33
 #define AT_SYSINFO		32
+#define AT_MINSIGSTKSZ		51
 
 struct auxv_entry {
 	long key;
@@ -237,6 +238,7 @@ void elf_ctx_init(struct ukarch_ctx *ctx, struct elf_prog *prog,
 		 */
 		{ AT_SYSINFO_EHDR, (uintptr_t)vdso_image_addr },
 #endif /* CONFIG_APPELFLOADER_VDSO */
+		{ AT_MINSIGSTKSZ, 2048 },
 		{ AT_IGNORE, 0x0 }
 	};
 	struct auxv_entry auxv_null = { AT_NULL, 0x0 };

--- a/elf_load.c
+++ b/elf_load.c
@@ -53,6 +53,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #endif /* CONFIG_HAVE_VFS */
+#if CONFIG_PLAT_HYPERLIGHT && CONFIG_LIBCPIOVFS
+#include <vfscore/file.h>
+#include <vfscore/vnode.h>
+#include <vfscore/dentry.h>
+#endif
 #include <uk/assert.h>
 #include <uk/print.h>
 #include <uk/essentials.h>
@@ -1047,7 +1052,39 @@ static struct elf_prog *do_elf_load_vfs(struct uk_alloc *a, const char *path,
 	uk_pr_debug("%s: Note, ignoring executable bit state\n", progname);
 #endif /* !CONFIG_APPELFLOADER_VFSEXEC_EXECBIT */
 
+#if CONFIG_PLAT_HYPERLIGHT && CONFIG_LIBCPIOVFS
+	/* On Hyperlight with cpiovfs, the file data is already in memory
+	 * (initrd).  Use a direct pointer via elf_memory() to avoid a
+	 * 100+ MB malloc+read that crashes the buddy allocator.
+	 */
+	{
+		/* Must match the cpiovfs_node layout in lib/cpiovfs/cpiovfs.c */
+		struct cpiovfs_node {
+			char *name;
+			size_t namelen;
+			int type;
+			mode_t mode;
+			uint64_t ino;
+			const char *data;
+			size_t size;
+			struct cpiovfs_node *child;
+			struct cpiovfs_node *next;
+		};
+		struct vfscore_file *fp = vfscore_get_file(fd);
+		struct cpiovfs_node *np;
+		if (!fp || !fp->f_dentry || !fp->f_dentry->d_vnode) {
+			uk_pr_err("%s: Cannot get vnode for %s\n",
+				  progname, path);
+			ret = -ENOENT;
+			goto err_close_fd;
+		}
+		np = (struct cpiovfs_node *)fp->f_dentry->d_vnode->v_data;
+		elf = elf_memory((char *)np->data, np->size);
+		vfscore_put_file(fp);
+	}
+#else
 	elf = elf_open(fd);
+#endif
 	if (unlikely(!elf)) {
 		elferr_err("%s: Failed to initialize ELF parser\n",
 			   progname);

--- a/elf_load.c
+++ b/elf_load.c
@@ -68,6 +68,19 @@
 #include "libelf_helper.h"
 #include "elf_prog.h"
 
+/* Fallback page alignment macros when paging is not configured.
+ * These provide basic 4KB page alignment needed for ELF loading.
+ */
+#ifndef PAGE_ALIGN_UP
+#define __PAGE_SIZE 4096UL
+#define PAGE_ALIGN_UP(addr) (((addr) + __PAGE_SIZE - 1) & ~(__PAGE_SIZE - 1))
+#endif
+
+#ifndef PAGE_ALIGNED
+#define __PAGE_SIZE_MASK (__PAGE_SIZE - 1)
+#define PAGE_ALIGNED(addr) (!((addr) & __PAGE_SIZE_MASK))
+#endif
+
 static int get_phdr_mmap_prot(GElf_Phdr *phdr)
 {
 	int mmap_prot = 0;

--- a/elf_load.c
+++ b/elf_load.c
@@ -744,6 +744,80 @@ static int elf_load_fd(struct elf_prog *elf_prog, Elf *elf, int fd)
 			return ret;
 	}
 
+#if !CONFIG_LIBPOSIX_MMAP
+	/*
+	 * Without POSIX mmap, the binary is loaded at vabase + p_vaddr,
+	 * not at p_vaddr directly.  For PIE (ET_DYN) binaries, internal
+	 * pointers need to be adjusted by the load delta.  Walk the RELA
+	 * section and apply R_X86_64_RELATIVE relocations.
+	 */
+	if (ehdr.e_type == ET_DYN) {
+		uintptr_t delta = (uintptr_t)elf_prog->vabase;
+
+		for (phi = 0; phi < phnum; ++phi) {
+			if (gelf_getphdr(elf, phi, &phdr) != &phdr)
+				continue;
+			if (phdr.p_type != PT_LOAD)
+				continue;
+			/* Find the RELA section within this LOAD segment */
+			Elf_Scn *scn = NULL;
+			while ((scn = elf_nextscn(elf, scn)) != NULL) {
+				GElf_Shdr shdr;
+				if (gelf_getshdr(scn, &shdr) != &shdr)
+					continue;
+				if (shdr.sh_type != SHT_RELA)
+					continue;
+				Elf_Data *rdata = elf_getdata(scn, NULL);
+				if (!rdata)
+					continue;
+				size_t nrel = shdr.sh_size / shdr.sh_entsize;
+				/* Pass 1: apply R_X86_64_RELATIVE */
+				for (size_t ri = 0; ri < nrel; ri++) {
+					GElf_Rela rela;
+					if (gelf_getrela(rdata, ri, &rela)
+					    != &rela)
+						continue;
+					if (GELF_R_TYPE(rela.r_info)
+					    != R_X86_64_RELATIVE)
+						continue;
+					uintptr_t *target =
+						(uintptr_t *)(delta
+							       + rela.r_offset);
+					*target = delta + rela.r_addend;
+				}
+				/* Pass 2: resolve R_X86_64_IRELATIVE
+				 * (resolvers may use RELATIVE-patched
+				 * GOT entries, so must run after pass 1)
+				 */
+				for (size_t ri = 0; ri < nrel; ri++) {
+					GElf_Rela rela;
+					if (gelf_getrela(rdata, ri, &rela)
+					    != &rela)
+						continue;
+					if (GELF_R_TYPE(rela.r_info)
+					    != R_X86_64_IRELATIVE)
+						continue;
+					typedef uintptr_t
+						(*ifunc_t)(void);
+					ifunc_t resolver =
+						(ifunc_t)(delta
+						+ rela.r_addend);
+					uintptr_t *target =
+						(uintptr_t *)(delta
+							       + rela.r_offset);
+					*target = resolver();
+				}
+				/* Only one RELA section expected */
+				break;
+			}
+			/* Only process once (not per LOAD) */
+			break;
+		}
+		uk_pr_info("%s: Applied PIE relocations (delta=0x%"PRIx64")\n",
+			   elf_prog->name, (uint64_t)delta);
+	}
+#endif /* !CONFIG_LIBPOSIX_MMAP */
+
 	return 0;
 
 err_free_img:

--- a/main.c
+++ b/main.c
@@ -601,7 +601,64 @@ int main(int argc, const char *argv[])
 #endif /* !CONFIG_LIBUKRANDOM */
 
 	uk_pr_debug("%s: Prepare application thread...\n", progname);
-	ret = elf_arg_env_count(&argc, argv, &envc, environ,
+
+	const char **eff_environ = environ;
+#if CONFIG_PLAT_HYPERLIGHT
+	/* Stuff two pointer-slot addresses into the loaded ELF's env so a
+	 * dynamically-linked driver that doesn't link against kernel
+	 * symbols can still read the current in-flight FunctionCall bytes:
+	 *   HL_FC_BYTES_PTR=0x<addr of slot holding (const u8 *)>
+	 *   HL_FC_LEN_PTR=0x<addr of slot holding (size_t)>
+	 * Both addresses are kernel .data globals — stable across snapshot
+	 * and restore, so the driver reads them once at init and then just
+	 * dereferences on every dispatch.
+	 */
+	extern const __u8 **hyperlight_dispatch_fc_bytes_slot(void);
+	extern __sz *hyperlight_dispatch_fc_len_slot(void);
+	typedef void (*hl_dispatch_fn)(const __u8 *, __sz);
+	extern hl_dispatch_fn *hyperlight_dispatch_v2_slot(void);
+	static char hl_fc_bytes_env[48];
+	static char hl_fc_len_env[48];
+	static char hl_v2_cb_env[52];
+
+	snprintf(hl_fc_bytes_env, sizeof(hl_fc_bytes_env),
+		 "HL_FC_BYTES_PTR=0x%lx",
+		 (unsigned long)hyperlight_dispatch_fc_bytes_slot());
+	snprintf(hl_fc_len_env, sizeof(hl_fc_len_env),
+		 "HL_FC_LEN_PTR=0x%lx",
+		 (unsigned long)hyperlight_dispatch_fc_len_slot());
+	snprintf(hl_v2_cb_env, sizeof(hl_v2_cb_env),
+		 "HL_V2_CALLBACK_PTR=0x%lx",
+		 (unsigned long)hyperlight_dispatch_v2_slot());
+
+	/* Count existing environ entries and build a merged array. The
+	 * buffer is static to avoid heap churn — elf_ctx_init copies the
+	 * strings into its infoblk so the pointers only need to outlive
+	 * that call.
+	 */
+	int base_envc = 0;
+	if (environ) {
+		while (environ[base_envc])
+			base_envc++;
+	}
+
+	static const char *hl_merged_env[64];
+	const int hl_extra = 3;
+	if (base_envc + hl_extra + 1 <= (int)ARRAY_SIZE(hl_merged_env)) {
+		for (int i = 0; i < base_envc; i++)
+			hl_merged_env[i] = environ[i];
+		hl_merged_env[base_envc]     = hl_fc_bytes_env;
+		hl_merged_env[base_envc + 1] = hl_fc_len_env;
+		hl_merged_env[base_envc + 2] = hl_v2_cb_env;
+		hl_merged_env[base_envc + 3] = NULL;
+		eff_environ = hl_merged_env;
+	} else {
+		uk_pr_warn("%s: skipping HL_FC_*_PTR env injection; "
+			   "too many existing env vars\n", progname);
+	}
+#endif /* CONFIG_PLAT_HYPERLIGHT */
+
+	ret = elf_arg_env_count(&argc, argv, &envc, eff_environ,
 				PAGES2BYTES(CONFIG_APPELFLOADER_STACK_NBPAGES));
 	if (unlikely(ret < 0)) {
 		uk_pr_err("Args + env size exceeds limit, increase stack size\n");
@@ -609,7 +666,7 @@ int main(int argc, const char *argv[])
 	}
 
 	elf_ctx_init(&app_thread->ctx, prog, progname,
-		     argc, argv, envc, environ, rand);
+		     argc, argv, envc, eff_environ, rand);
 #if !CONFIG_PLAT_HYPERLIGHT
 	/* Mark the thread as runnable for the scheduler.
 	 * On Hyperlight, the dispatch callback runs the thread directly

--- a/main.c
+++ b/main.c
@@ -39,10 +39,14 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <uk/errptr.h>
 #include <uk/essentials.h>
 #include <uk/plat/memory.h>
+#if CONFIG_PLAT_HYPERLIGHT
+#include <uk/pm.h>
+#endif
 #if CONFIG_LIBPOSIX_PROCESS
 #include <uk/process.h>
 #endif /* CONFIG_LIBPOSIX_PROCESS */
@@ -180,6 +184,214 @@ static __constructor void _libelf_init(void) {
 		UK_CRASH("Failed to initialize libelf: Version error");
 }
 
+#if CONFIG_PLAT_HYPERLIGHT
+/* Forward declarations — defined in plat/hyperlight/dispatch.c */
+extern void hyperlight_dispatch_register(void (*fn)(void));
+extern void hyperlight_dispatch_set_elf_entry(__u64 entry);
+extern __u64 hyperlight_dispatch_get_elf_entry(void);
+
+
+static struct uk_thread *hyperlight_deferred_thread;
+static struct uk_sched *hyperlight_deferred_sched;
+extern __uptr hyperlight_kernel_fsbase; /* defined in arch/x86/sysctx.c */
+static __uptr hyperlight_elf_main_addr; /* main() in loaded ELF (0 = use _start) */
+static __uptr hyperlight_elf_libc_addr; /* musl __libc struct in loaded ELF */
+
+/**
+ * Find "main" and "__libc" symbols in an ELF binary's .symtab section.
+ * Populates main_out/libc_out with st_value (virtual address), 0 if not found.
+ */
+static void find_elf_symbols(const char *path,
+			     __u64 *main_out, __u64 *libc_out)
+{
+	int fd;
+	__u8 ehdr[64];
+	ssize_t n;
+
+	*main_out = 0;
+	*libc_out = 0;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return;
+
+	/* Read ELF header (64 bytes for Elf64) */
+	n = read(fd, ehdr, 64);
+	if (n < 64)
+		goto out;
+
+	__u64 e_shoff = *(__u64 *)(ehdr + 40);
+	__u16 e_shentsize = *(__u16 *)(ehdr + 58);
+	__u16 e_shnum = *(__u16 *)(ehdr + 60);
+
+	if (!e_shoff || !e_shnum || e_shentsize < 64)
+		goto out;
+
+	/* Iterate section headers to find SHT_SYMTAB */
+	__u64 symtab_off = 0, symtab_sz = 0, symtab_entsz = 0;
+	__u64 strtab_off = 0, strtab_sz = 0;
+	__u32 symtab_link = 0;
+
+	for (__u16 i = 0; i < e_shnum; i++) {
+		__u8 shdr[64];
+
+		if (lseek(fd, e_shoff + (__u64)i * e_shentsize, SEEK_SET) < 0)
+			goto out;
+		n = read(fd, shdr, 64);
+		if (n < 64)
+			goto out;
+
+		__u32 sh_type = *(__u32 *)(shdr + 4);
+		if (sh_type == 2) { /* SHT_SYMTAB */
+			symtab_off = *(__u64 *)(shdr + 24);
+			symtab_sz = *(__u64 *)(shdr + 32);
+			symtab_link = *(__u32 *)(shdr + 40);
+			symtab_entsz = *(__u64 *)(shdr + 56);
+			break;
+		}
+	}
+
+	if (!symtab_off || !symtab_entsz)
+		goto out;
+
+	/* Read the linked .strtab section header */
+	{
+		__u8 shdr[64];
+
+		if (lseek(fd, e_shoff + (__u64)symtab_link * e_shentsize, SEEK_SET) < 0)
+			goto out;
+		n = read(fd, shdr, 64);
+		if (n < 64)
+			goto out;
+		strtab_off = *(__u64 *)(shdr + 24);
+		strtab_sz = *(__u64 *)(shdr + 32);
+	}
+
+	if (!strtab_off || !strtab_sz)
+		goto out;
+
+	/* Read .strtab into a buffer */
+	char *strtab = malloc(strtab_sz);
+	if (!strtab)
+		goto out;
+	if (lseek(fd, strtab_off, SEEK_SET) < 0) {
+		free(strtab);
+		goto out;
+	}
+	n = read(fd, strtab, strtab_sz);
+	if (n < (ssize_t)strtab_sz) {
+		free(strtab);
+		goto out;
+	}
+
+	/* Iterate .symtab entries to find "main" and "__libc" */
+	__u64 num_syms = symtab_sz / symtab_entsz;
+	for (__u64 i = 0; i < num_syms; i++) {
+		__u8 sym[24]; /* Elf64_Sym is 24 bytes */
+
+		if (lseek(fd, symtab_off + i * symtab_entsz, SEEK_SET) < 0)
+			break;
+		n = read(fd, sym, 24);
+		if (n < 24)
+			break;
+
+		__u32 st_name = *(__u32 *)(sym + 0);
+		__u8 st_info = sym[4];
+		__u64 st_value = *(__u64 *)(sym + 8);
+		__u8 st_type = st_info & 0xf;
+		__u8 st_bind = st_info >> 4;
+
+		if (!st_value || st_name >= strtab_sz)
+			continue;
+		if (st_bind != 1) /* STB_GLOBAL */
+			continue;
+
+		const char *name = strtab + st_name;
+
+		/* main: GLOBAL FUNC */
+		if (st_type == 2 && !*main_out &&
+		    name[0] == 'm' && name[1] == 'a' &&
+		    name[2] == 'i' && name[3] == 'n' && name[4] == '\0') {
+			*main_out = st_value;
+		}
+		/* __libc: GLOBAL OBJECT */
+		if (st_type == 1 && !*libc_out &&
+		    name[0] == '_' && name[1] == '_' &&
+		    name[2] == 'l' && name[3] == 'i' &&
+		    name[4] == 'b' && name[5] == 'c' && name[6] == '\0') {
+			*libc_out = st_value;
+		}
+		if (*main_out && *libc_out)
+			break;
+	}
+
+	free(strtab);
+out:
+	close(fd);
+}
+
+static void hyperlight_deferred_run(void)
+{
+	/* Step 1: IDT/IST pre-fault + MSR restore is now handled by
+	 * hyperlight_dispatch_prepare() in dispatch.c, called from
+	 * hyperlight_dispatch_inner() before this callback.
+	 */
+
+	/* Step 2: Restore FS base (TLS) for kernel services */
+	if (hyperlight_kernel_fsbase) {
+		__u32 lo = (__u32)hyperlight_kernel_fsbase;
+		__u32 hi = (__u32)(hyperlight_kernel_fsbase >> 32);
+		__asm__ volatile("wrmsr" : : "c"(0xC0000100), "a"(lo), "d"(hi));
+	}
+
+	/* Step 3: Restore the fd table for this TLS context */
+	{
+		extern void hyperlight_fdtab_restore_active(void);
+		hyperlight_fdtab_restore_active();
+	}
+
+	/* Step 4: Call main() directly or jump to _start as fallback */
+	if (hyperlight_elf_main_addr) {
+		/* Parse argc/argv/envp from the prepared stack.
+		 * ukarch_ctx_init() pushes 2 context frames (entry + call0)
+		 * below the application stack, so ctx.sp is 16 bytes below argc.
+		 */
+		__uptr sp = hyperlight_deferred_thread->ctx.sp + 16;
+		int argc = (int)(*(long *)sp);
+		char **argv = (char **)(sp + sizeof(long));
+		char **envp = argv + argc + 1;
+
+		/* Set musl libc.auxv so malloc/stdio work without __init_libc */
+		if (hyperlight_elf_libc_addr) {
+			char **p = envp;
+			while (*p) p++;
+			p++; /* skip NULL terminator */
+			*((__u64 *)(hyperlight_elf_libc_addr + 8)) = (__u64)p;
+		}
+
+		typedef int (*main_fn_t)(int, char **, char **);
+		main_fn_t fn = (main_fn_t)hyperlight_elf_main_addr;
+		fn(argc, argv, envp);
+		/* main() returned — dispatch completes normally */
+	} else {
+		/* No main() found — fall back to _start dispatch.
+		 * ukarch_ctx_init() pushes 2 context frames (entry + call0)
+		 * below the application stack, so ctx.sp is 16 bytes below argc.
+		 */
+		__uptr entry = (__uptr)hyperlight_dispatch_get_elf_entry();
+		__uptr orig_sp = hyperlight_deferred_thread->ctx.sp + 16;
+		__asm__ volatile(
+			"movq %0, %%rsp\n\t"
+			"xorq %%rbp, %%rbp\n\t"
+			"jmpq *%1\n\t"
+			: : "r"(orig_sp), "r"(entry)
+			: "memory"
+		);
+		__builtin_unreachable();
+	}
+}
+#endif /* CONFIG_PLAT_HYPERLIGHT */
+
 int main(int argc, const char *argv[])
 {
 #if CONFIG_APPELFLOADER_INITRDEXEC
@@ -258,6 +470,11 @@ int main(int argc, const char *argv[])
 	argv = &argv[1];
 	argc -= 1;
 
+	/* NOTE: elf_ctx_init() prepends progname as argv[0], so we
+	 * do NOT need to manually prepend path here.  argv currently
+	 * contains just the app arguments (e.g., ["/demo.sh"]).
+	 */
+
 #endif /* !CONFIG_APPELFLOADER_CUSTOMAPPNAME */
 
 #if CONFIG_APPELFLOADER_VFSEXEC_ENVPATH
@@ -276,14 +493,20 @@ int main(int argc, const char *argv[])
 	}
 #endif /* CONFIG_APPELFLOADER_VFSEXEC_ENVPATH */
 
-#if CONFIG_LIBPOSIX_PROCESS_EXECVE && CONFIG_APPELFLOADER_VFSEXEC
+#if CONFIG_LIBPOSIX_PROCESS_EXECVE && CONFIG_APPELFLOADER_VFSEXEC \
+    && !CONFIG_PLAT_HYPERLIGHT
+	/* On Hyperlight we skip execve() and use the deferred-dispatch path
+	 * (load ELF, create thread, register dispatch callback, return).
+	 * execve() would run the binary immediately during evolve, bypassing
+	 * the snapshot/restore/call lifecycle.
+	 */
 	ret = execve(realpath ? realpath : path,
 		     (char * const *)argv, (char * const *)environ);
 	if (unlikely(ret)) {
 		uk_pr_err("Could not execve (%d)\n", ret);
 		goto out;
 	}
-#endif /* CONFIG_LIBPOSIX_PROCESS_EXECVE && CONFIG_APPELFLOADER_VFSEXEC */
+#endif /* CONFIG_LIBPOSIX_PROCESS_EXECVE && !CONFIG_PLAT_HYPERLIGHT */
 
 #if CONFIG_APPELFLOADER_INITRDEXEC
 	/*
@@ -387,7 +610,15 @@ int main(int argc, const char *argv[])
 
 	elf_ctx_init(&app_thread->ctx, prog, progname,
 		     argc, argv, envc, environ, rand);
+#if !CONFIG_PLAT_HYPERLIGHT
+	/* Mark the thread as runnable for the scheduler.
+	 * On Hyperlight, the dispatch callback runs the thread directly
+	 * (bypassing the scheduler), so we must NOT set RUNNABLE here —
+	 * otherwise create_pthread would add it to the scheduler and it
+	 * would execute during evolve before dispatch is registered.
+	 */
 	app_thread->flags |= UK_THREADF_RUNNABLE;
+#endif
 
 #if CONFIG_LIBPOSIX_PROCESS_MULTITHREADING
 	/* Add application thread to process */
@@ -411,6 +642,67 @@ int main(int argc, const char *argv[])
 	/*
 	 * Execute application
 	 */
+#if CONFIG_PLAT_HYPERLIGHT
+	/*
+	 * On Hyperlight, defer execution: store the app thread and
+	 * scheduler so the dispatch function can run them on call().
+	 * Return from main() — boot.c shutdown signals readiness to
+	 * the host with the dispatch function address in RAX.
+	 */
+	hyperlight_deferred_thread = app_thread;
+	hyperlight_deferred_sched = s;
+	/* Store the ELF entry address for use after restore.
+	 * For dynamically-linked binaries, use the interpreter's entry —
+	 * the dynamic linker must run before the main binary's _start.
+	 */
+	if (prog->interp.required)
+		hyperlight_dispatch_set_elf_entry(
+			(__u64)prog->interp.prog->entry);
+	else
+		hyperlight_dispatch_set_elf_entry((__u64)prog->entry);
+	/* Find main() and __libc in the ELF symbol table for direct dispatch.
+	 * Calling main() directly avoids _start which triggers musl's TLS init
+	 * (overriding FS_BASE) and PIE re-relocation.
+	 * __libc is needed to set libc.auxv so malloc/stdio work.
+	 *
+	 * Skip for dynamically-linked binaries (interp.required): the dynamic
+	 * linker must run first to resolve GOT/PLT entries before main() can
+	 * be called.  Fall through to the _start path instead.
+	 */
+	if (!prog->interp.required) {
+		__u64 main_vaddr, libc_vaddr;
+		find_elf_symbols(prog->path, &main_vaddr, &libc_vaddr);
+		if (main_vaddr)
+			hyperlight_elf_main_addr = (__uptr)prog->vabase + main_vaddr;
+		if (libc_vaddr)
+			hyperlight_elf_libc_addr = (__uptr)prog->vabase + libc_vaddr;
+	}
+	/* Leave .dynamic intact: the elfloader already applied RELATIVE
+	 * and IRELATIVE relocations, and glibc/musl re-applying them
+	 * during _start is idempotent.  Keeping .dynamic allows libc
+	 * to find DT_INIT_ARRAY and complete its own initialization
+	 * (TLS, locale, etc.) when entering via _start.
+	 */
+	/* Re-save LSTAR here (after _init_syscall has set it during boot) */
+	{
+		extern void hyperlight_dispatch_save_msrs(void);
+		hyperlight_dispatch_save_msrs();
+	}
+	/* Save FS base (TLS) via rdmsr — needed after restore for kernel services */
+	{
+		__u32 lo, hi;
+		__asm__ volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(0xC0000100));
+		hyperlight_kernel_fsbase = ((__uptr)hi << 32) | lo;
+	}
+	hyperlight_dispatch_register(hyperlight_deferred_run);
+	/* Halt directly — do not return to boot.c's shutdown machinery.
+	 * The cooperative scheduler's idle thread would do a bare HLT
+	 * (without outl 108), which the host misinterprets.
+	 * ukplat_terminate goes through the proper Hyperlight halt path:
+	 * push void result → load dispatch_function into RAX → outl 108.
+	 */
+	uk_pm_shutdown(UK_PM_SHUTDOWN_OP_SYSHALT);
+#else
 	uk_sched_thread_add(s, app_thread);
 
 	/*
@@ -420,6 +712,7 @@ int main(int argc, const char *argv[])
 	 */
 	for (;;)
 		sleep(10);
+#endif
 
 out_free_thread:
 	uk_thread_release(app_thread);


### PR DESCRIPTION
## Summary

The following changes to app-elfloader were necessary to support Hyperlight as a Unikraft platform:

- Add `AT_MINSIGSTKSZ` auxiliary vector entry for glibc 2.34+ compatibility
- Add page alignment macros and PIE relocation handling (R_X86_64_RELATIVE, R_X86_64_IRELATIVE) for builds without POSIX mmap
- Use `elf_memory()` with cpiovfs for zero-copy ELF loading on Hyperlight, avoiding large heap allocations
- Implement deferred execution lifecycle: skip `execve()`, find `main`/`__libc` symbols, register a dispatch callback, and halt via `uk_pm` — enabling Hyperlight's snapshot/restore/call model
- Inject `HL_FC_BYTES_PTR`, `HL_FC_LEN_PTR`, and `HL_V2_CALLBACK_PTR` environment variables so dynamically-linked drivers can access dispatch state without linking kernel symbols